### PR TITLE
Revise Intake code to allow the beam break note alignment to run even when not holding the button

### DIFF
--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -102,17 +102,11 @@ public class RobotContainer {
 
     // TODO: maybe find a cleaner way to implement this. also includes running the
     // pivot function constantly during auto
-    NamedCommands.registerCommand("startAutoAim", Commands.runOnce(() -> {
-      m_autoAim = true;
-    }).asProxy());
+    NamedCommands.registerCommand("startAutoAim", Commands.runOnce(() -> m_autoAim = true).asProxy());
 
-    NamedCommands.registerCommand("stopAutoAim", Commands.runOnce(() -> {
-      m_autoAim = false;
-    }).asProxy());
+    NamedCommands.registerCommand("stopAutoAim", Commands.runOnce(() -> m_autoAim = false).asProxy());
 
-    NamedCommands.registerCommand("zeroGyro", Commands.runOnce(() -> {
-      m_robotDrive.resetGyro();
-    }).asProxy());
+    NamedCommands.registerCommand("zeroGyro", Commands.runOnce(m_robotDrive::resetGyro).asProxy());
 
     NamedCommands.registerCommand("pivotSubwoofer",
         m_attatchment.getSetPivotPositionCommand(PivotPosition.kSubwooferPosition));
@@ -141,7 +135,7 @@ public class RobotContainer {
 
     // Set X wheels
     m_driverController.rightBumper().whileTrue(Commands.run(
-        () -> m_robotDrive.setX(),
+        m_robotDrive::setX,
         m_robotDrive));
 
     // Auto aiming
@@ -151,18 +145,20 @@ public class RobotContainer {
     }));
 
     // Reset field oriented
-    m_driverController.x().onTrue(Commands.runOnce(() -> {
-      m_robotDrive.resetGyro();
-    }));
+    m_driverController.x().onTrue(Commands.runOnce(m_robotDrive::resetGyro));
 
     // D-pad turning
-    m_driverController.povUp().whileTrue(Commands.run(() -> autoAimDrive(Rotation2d.fromDegrees(getFromAlliance(0, 180))), m_robotDrive));
+    m_driverController.povUp()
+        .whileTrue(Commands.run(() -> autoAimDrive(Rotation2d.fromDegrees(getFromAlliance(0, 180))), m_robotDrive));
 
-    m_driverController.povRight().whileTrue(Commands.run(() -> autoAimDrive(Rotation2d.fromDegrees(getFromAlliance(-90, 90))), m_robotDrive));
+    m_driverController.povRight()
+        .whileTrue(Commands.run(() -> autoAimDrive(Rotation2d.fromDegrees(getFromAlliance(-90, 90))), m_robotDrive));
 
-    m_driverController.povDown().whileTrue(Commands.run(() -> autoAimDrive(Rotation2d.fromDegrees(getFromAlliance(180, 0))), m_robotDrive));
+    m_driverController.povDown()
+        .whileTrue(Commands.run(() -> autoAimDrive(Rotation2d.fromDegrees(getFromAlliance(180, 0))), m_robotDrive));
 
-    m_driverController.povLeft().whileTrue(Commands.run(() -> autoAimDrive(Rotation2d.fromDegrees(getFromAlliance(90, -90))), m_robotDrive));
+    m_driverController.povLeft()
+        .whileTrue(Commands.run(() -> autoAimDrive(Rotation2d.fromDegrees(getFromAlliance(90, -90))), m_robotDrive));
 
     // Attatchment controls
 
@@ -221,7 +217,7 @@ public class RobotContainer {
   }
 
   public double invertIfRed(double num) {
-     return num * getFromAlliance(1, -1);
+    return num * getFromAlliance(1, -1);
   }
 
   public Translation2d getTarget() {
@@ -259,8 +255,8 @@ public class RobotContainer {
   }
 
   public void prepareTeleop() {
-      m_attatchment.stopContinuousFire();
-      m_autoAim = false;
+    m_attatchment.stopContinuousFire();
+    m_autoAim = false;
   }
 
   /**
@@ -272,8 +268,8 @@ public class RobotContainer {
     // Stop continuous fire and auto aim after auto ends
     return autoChooser.getSelected().finallyDo(() -> {
       // shooter stops too early for the third note sometimes
-      //m_attatchment.stopContinuousFire();
-     // m_autoAim = false;
+      // m_attatchment.stopContinuousFire();
+      // m_autoAim = false;
     });
   }
 }

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -163,7 +163,7 @@ public class RobotContainer {
     // Attatchment controls
 
     // Intake
-    m_attachmentController.b().whileTrue(m_attatchment.getIntakeCommand());
+    m_attatchment.bindIntakeTrigger(m_attachmentController.b());
 
     // Unjam
     m_attachmentController.y().whileTrue(m_attatchment.getUnjamIntakersCommand());

--- a/src/main/java/frc/robot/commands/AttachmentCoordinator.java
+++ b/src/main/java/frc/robot/commands/AttachmentCoordinator.java
@@ -154,6 +154,7 @@ public class AttachmentCoordinator {
 
     /**
      * Intake untul the returned command is canceled
+     * If you want to intake based on a joystick button or other trigger, use {@link #bindIntakeTrigger() bindIntakeTrigger}
      * 
      * @return a command to intake
      */
@@ -165,10 +166,25 @@ public class AttachmentCoordinator {
                     m_feeder.setState(FeederState.kAlignReverse);
                 }, m_UTBIntaker, m_feeder),
                 Commands.race(Commands.waitUntil(m_beamBreak.negate()),
-                        Commands.waitSeconds(FeederConstants.kNotePullbackMaxTime)),
+                        Commands.waitSeconds(FeederConstants.kNotePullbackMaxTime))
+        ).finallyDo(() -> stopIntaking());
+    }
+
+    /**
+     * Bind intaking to a trigger so it can cancel intaking but not note alignment
+     * This should only be called once, for multiple triggers use the trigger composing methods.
+     */
+    public void bindIntakeTrigger(Trigger intakeTrgger) {
+        // TODO: bind command to trigger onTrue
+        Command intakeCommand = Commands.sequence(
+            Commands.runOnce(() -> startIntaking(), m_UTBIntaker, m_feeder),
+            // TODO: if trigger false before beam break, cancel
+                Commands.waitUntil(m_beamBreak),
                 Commands.runOnce(() -> {
-                    m_feeder.setState(FeederState.kStopped);
-                }, m_UTBIntaker, m_feeder)
+                    m_feeder.setState(FeederState.kAlignReverse);
+                }, m_UTBIntaker, m_feeder),
+                Commands.race(Commands.waitUntil(m_beamBreak.negate()),
+                        Commands.waitSeconds(FeederConstants.kNotePullbackMaxTime))
         ).finallyDo(() -> stopIntaking());
     }
 

--- a/src/main/java/frc/robot/commands/AttachmentCoordinator.java
+++ b/src/main/java/frc/robot/commands/AttachmentCoordinator.java
@@ -34,7 +34,6 @@ public class AttachmentCoordinator {
     private AttatchmentState m_state = AttatchmentState.kAiming;
     private AimingTarget m_target = AimingTarget.kSpeaker;
 
-
     public AttachmentCoordinator(UTBIntakerSubsystem utbIntaker, FeederSubsystem feeder, ShooterSubsystem shooter,
             PivotSubsystem pivot) {
         m_UTBIntaker = utbIntaker;
@@ -47,21 +46,18 @@ public class AttachmentCoordinator {
 
     // Starts the beam break trigger for teleop
     public void bindControllerRumble(CommandXboxController driveController) {
-        // Rumble on intake (this mess makes it so it doesn't rumble while shooting and only for intaking)
+        // Rumble on intake (this mess makes it so it doesn't rumble while shooting and
+        // only for intaking)
         m_beamBreak.onTrue(
-            Commands.parallel(
-                Commands.either(                
-                    Commands.sequence(
-                    Commands.runOnce(() -> {
-                        driveController.getHID().setRumble(RumbleType.kBothRumble, 1);
-                    }),
-                    Commands.waitSeconds(1),
-                    Commands.runOnce(() -> {
-                        driveController.getHID().setRumble(RumbleType.kBothRumble, 0);
-                    })
-                ),
-                Commands.none(), () -> m_state == AttatchmentState.kAiming))
-        );
+                Commands.parallel(
+                        Commands.either(
+                                Commands.sequence(
+                                        Commands.runOnce(
+                                                () -> driveController.getHID().setRumble(RumbleType.kBothRumble, 1)),
+                                        Commands.waitSeconds(1),
+                                        Commands.runOnce(
+                                                () -> driveController.getHID().setRumble(RumbleType.kBothRumble, 0))),
+                                Commands.none(), () -> m_state == AttatchmentState.kAiming)));
     }
 
     private void setState(AttatchmentState state) {
@@ -136,6 +132,15 @@ public class AttachmentCoordinator {
         m_shooter.setState(state);
     }
 
+    private Command getAlignNoteCommand() {
+        return Commands.sequence(
+                Commands.runOnce(() -> m_feeder.setState(FeederState.kAlignReverse), m_UTBIntaker, m_feeder),
+                Commands.race(
+                        Commands.waitUntil(m_beamBreak.negate()),
+                        Commands.waitSeconds(FeederConstants.kNotePullbackMaxTime)),
+                Commands.runOnce(this::stopIntaking, m_UTBIntaker, m_feeder));
+    }
+
     /**
      * Set the target for auto aiming This should be the same target that the
      * drivebase is targeting
@@ -154,42 +159,38 @@ public class AttachmentCoordinator {
 
     /**
      * Intake untul the returned command is canceled
-     * If you want to intake based on a joystick button or other trigger, use {@link #bindIntakeTrigger() bindIntakeTrigger}
+     * If you want to intake based on a joystick button or other trigger, use
+     * {@link #bindIntakeTrigger() bindIntakeTrigger}
      * 
      * @return a command to intake
      */
     public Command getIntakeCommand() {
         return Commands.sequence(
-            Commands.runOnce(() -> startIntaking(), m_UTBIntaker, m_feeder),
+                Commands.runOnce(this::startIntaking, m_UTBIntaker, m_feeder),
                 Commands.waitUntil(m_beamBreak),
-                Commands.runOnce(() -> {
-                    m_feeder.setState(FeederState.kAlignReverse);
-                }, m_UTBIntaker, m_feeder),
-                Commands.race(Commands.waitUntil(m_beamBreak.negate()),
-                        Commands.waitSeconds(FeederConstants.kNotePullbackMaxTime))
-        ).finallyDo(() -> stopIntaking());
+                getAlignNoteCommand()).finallyDo(this::stopIntaking);
     }
 
     /**
      * Bind intaking to a trigger so it can cancel intaking but not note alignment
-     * This should only be called once, for multiple triggers use the trigger composing methods.
+     * This should only be called once, for multiple triggers use the trigger
+     * composition methods.
      */
     public void bindIntakeTrigger(Trigger intakeTrgger) {
-        // TODO: bind command to trigger onTrue
         Command intakeCommand = Commands.sequence(
-            Commands.runOnce(() -> startIntaking(), m_UTBIntaker, m_feeder),
-            // TODO: if trigger false before beam break, cancel
-                Commands.waitUntil(m_beamBreak),
-                Commands.runOnce(() -> {
-                    m_feeder.setState(FeederState.kAlignReverse);
-                }, m_UTBIntaker, m_feeder),
-                Commands.race(Commands.waitUntil(m_beamBreak.negate()),
-                        Commands.waitSeconds(FeederConstants.kNotePullbackMaxTime))
-        ).finallyDo(() -> stopIntaking());
+                Commands.runOnce(this::startIntaking, m_UTBIntaker, m_feeder),
+                // Run until beam break datects note or intake trigger becomes false
+                Commands.waitUntil(m_beamBreak.or(intakeTrgger.negate())),
+                // If the intake trigger is true, then the previous command
+                // stopped due to the beam break sensor
+                Commands.either(getAlignNoteCommand(), Commands.none(), intakeTrgger::getAsBoolean))
+                .finallyDo(this::stopIntaking);
+
+        intakeTrgger.onTrue(intakeCommand);
     }
 
     public Command getIntakeAutoCommand() {
-        return Commands.runOnce(() -> startIntaking(), m_UTBIntaker, m_feeder);
+        return Commands.runOnce(this::startIntaking, m_UTBIntaker, m_feeder);
     }
 
     /**
@@ -198,7 +199,7 @@ public class AttachmentCoordinator {
      * @return a command to unjam
      */
     public Command getUnjamIntakersCommand() {
-        return Commands.startEnd(() -> unjamIntakers(), () -> stopIntaking(), m_UTBIntaker, m_feeder);
+        return Commands.startEnd(this::unjamIntakers, this::stopIntaking, m_UTBIntaker, m_feeder);
     }
 
     /**
@@ -221,11 +222,11 @@ public class AttachmentCoordinator {
             setState(AttatchmentState.kShooting);
             m_feeder.setState(FeederState.kShooting);
         },
-        () -> {
-            setState(AttatchmentState.kAiming);
-            m_feeder.setState(FeederState.kStopped);
-            m_pivot.setPosition(PivotPosition.kIntakePosition);
-        });
+                () -> {
+                    setState(AttatchmentState.kAiming);
+                    m_feeder.setState(FeederState.kStopped);
+                    m_pivot.setPosition(PivotPosition.kIntakePosition);
+                });
     }
 
     // Starts shooting without stopping
@@ -239,14 +240,14 @@ public class AttachmentCoordinator {
     // Stops shooting
     public Command getStopShootCommand() {
         return Commands.sequence(
-        Commands.waitSeconds(0.2),   
-        Commands.runOnce(() -> {
-            setState(AttatchmentState.kAiming);
-            m_feeder.setState(FeederState.kStopped);
-            if (m_pivot.getPrecisePosition() != PivotConstants.kAmpPos) {
-                m_pivot.setPosition(PivotPosition.kIntakePosition);
-            }
-        }));
+                Commands.waitSeconds(0.2),
+                Commands.runOnce(() -> {
+                    setState(AttatchmentState.kAiming);
+                    m_feeder.setState(FeederState.kStopped);
+                    if (m_pivot.getPrecisePosition() != PivotConstants.kAmpPos) {
+                        m_pivot.setPosition(PivotPosition.kIntakePosition);
+                    }
+                }));
     }
 
     // Starts continuous fire without stopping
@@ -261,10 +262,10 @@ public class AttachmentCoordinator {
 
     public void stopContinuousFire() {
         setState(AttatchmentState.kAiming);
-            m_pivot.setPosition(PivotPosition.kIntakePosition);
-            m_shooter.setState(ShooterState.kStopped);
-            m_feeder.setState(FeederState.kStopped);
-            m_UTBIntaker.setState(IntakerState.kStopped);
+        m_pivot.setPosition(PivotPosition.kIntakePosition);
+        m_shooter.setState(ShooterState.kStopped);
+        m_feeder.setState(FeederState.kStopped);
+        m_UTBIntaker.setState(IntakerState.kStopped);
     }
 
     // Stops continuous fire
@@ -281,9 +282,7 @@ public class AttachmentCoordinator {
      * @return a command to set the pivot position
      */
     public Command getSetPivotPositionCommand(PivotPosition position) {
-        return Commands.runOnce(() -> {
-            m_pivot.setPosition(position);
-        }, m_pivot);
+        return Commands.runOnce(() -> m_pivot.setPosition(position), m_pivot);
     }
 
     /**

--- a/src/main/java/frc/robot/commands/AttachmentCoordinator.java
+++ b/src/main/java/frc/robot/commands/AttachmentCoordinator.java
@@ -173,7 +173,7 @@ public class AttachmentCoordinator {
 
     /**
      * Bind intaking to a trigger so it can cancel intaking but not note alignment
-     * This should only be called once, for multiple triggers use the trigger
+     * This should only be called once. For multiple triggers use the trigger
      * composition methods.
      */
     public void bindIntakeTrigger(Trigger intakeTrgger) {


### PR DESCRIPTION
This code is as of yet untested, but compiles with no errors and looks as good as it can not on the robot.

Key changes: Changed several lambdas that call functions with no arguments to method references, eg `Commands.runOnce(() -> someClass.instanceMethod(), subsystem)` was changed to `Commands.runOnce(someClass::instanceMethod, subsystem)` and unnecessary brackets around one function lambdas were also removed, to make code shorter and more clear.

Note that this pr is open because I have finished the code for now, but It should be merged whenever it is ready and tested on the robot.
This space can also be used to comment and review the changes before merging :)